### PR TITLE
added shield to RapidAPI

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [![Coverage Status](https://coveralls.io/repos/cpliakas/bigoven-php/badge.png?branch=master)](https://coveralls.io/r/cpliakas/bigoven-php?branch=master)
 [![Total Downloads](https://poser.pugx.org/cpliakas/bigoven-php/downloads.png)](https://packagist.org/packages/cpliakas/bigoven-php)
 [![Latest Stable Version](https://poser.pugx.org/cpliakas/bigoven-php/v/stable.png)](https://packagist.org/packages/cpliakas/bigoven-php)
+[![API Testing](https://img.shields.io/badge/API%20Test-RapidAPI-blue.svg)](https://rapidapi.com/package/BigOven/functions?utm_source=BigOvenGithub&utm_medium=button&utm_content=Vender_GitHub)
 
 A PHP client library for the [BigOven](http://www.bigoven.com/) API.
 


### PR DESCRIPTION
Hey there. I added a link to the README for a tool where you can test out the BigOven API calls in your browser. It's pretty cool because you can export the code snippet into multiple languages as well. I thought it would be useful because I've seen it on other SDKs (Telegram, Shopify and LinkedIn). Full disclosure--I do work on the team that built this tool, but honestly, people seem to find it useful for this kind of stuff.